### PR TITLE
Apollo federated router to serve the Hub API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+secrets.*

--- a/README.md
+++ b/README.md
@@ -4,16 +4,32 @@ Holaplex Hub console
 
 ## Getting Started
 
-The hub development environment runs within a local Kubernetes cluster using [skaffold](https://skaffold.dev/). Skaffold will setup the complete Holaplex API and setup hot reloading for the Hub UI.
+The Hub development environment runs within a local Kubernetes cluster using [skaffold](https://skaffold.dev/). Skaffold will setup the complete Holaplex API and setup hot reloading for the Hub UI.
 
 ### Dependencies
+
 - [Docker for Desktop](https://docs.docker.com/desktop/)
 - [Skaffold](https://skaffold.dev/)
 
+There are some secrets required for the API. Reach out to a fellow engineer to to get the secrets files. They should be placed in the root of the project and follow the pattern of secret.{service}.yaml.
+
+```
+/src
+skaffold.yaml
+secrets.router.yaml
+```
+
 ```bash
-skaffold dev --port-forward
+skaffold dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+
+Skaffold will expose the UI and API on the following ports:
+
+| Service | Endpoint                                       |
+| ------- | ---------------------------------------------- |
+| Hub UI  | [http://localhost:3000](http://localhost:3000) |
+| Hub API | http://localhost:3001                          |

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -25,6 +25,11 @@ portForward:
   namespace: default
   port: 80
   localPort: 3000
+- resourceType: service
+  resourceName: federated-router
+  namespace: default
+  port: 80
+  localPort: 3001
 deploy:
   helm:
     releases:
@@ -53,3 +58,8 @@ deploy:
         repo: https://charts.holaplex.com
         valuesFiles:
           - values.orgs.yaml
+      - name: federated-router
+        remoteChart: oci://ghcr.io/apollographql/helm-charts/router
+        valuesFiles:
+          - values.router.yaml
+          - secrets.router.yaml

--- a/values.kratos.yaml
+++ b/values.kratos.yaml
@@ -24,7 +24,7 @@ kratos:
       smtp:
         connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true
     selfservice:
-      default_browser_return_url: http://127.0.0.1:3000/
+      default_browser_return_url: http://localhost:3000/
   identitySchemas:
     "identity.default.schema.json": |-
       {

--- a/values.router.yaml
+++ b/values.router.yaml
@@ -1,0 +1,2 @@
+managedFederation:
+  graphRef: hub-dev@current


### PR DESCRIPTION
## Changes
- Launch apollo federated router pulls schema from apollo studio
- Include api key for apollo studio in git ignored file secrets.router.yaml