### PR TITLE
remove old reference to apisix helm chart and kustomize

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ There are some secrets required for the API. Reach out to a fellow engineer to t
 /src
 skaffold.yaml
 secrets.router.yaml
+secrets.gateway.yaml
 ```
 
 ### Deploy

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -77,5 +77,7 @@ deploy:
         namespace: ingress-apisix
         remoteChart: hub-gateway
         repo: https://charts.holaplex.com
+        #chartPath: ./../helm-charts/charts/hub-gateway
         valuesFiles:
           - values.gateway.yaml
+          - secrets.gateway.yaml

--- a/values.gateway.yaml
+++ b/values.gateway.yaml
@@ -1,3 +1,43 @@
 hubNamespace: default
+routes:
+- name: api
+  serviceName: federated-router
+  servicePort: 80
+  subdomain: api
+  paths:
+    - /graphql
+  methods:
+    - GET
+    - POST
+  require_auth: true
+  regex_uri: ["/graphql", "/"]
+  #policy: "hub/graphql/example"
+  #schema_query: "{ _service { sdl } }"
 
+- name: ui-public
+  subdomain: hub
+  serviceName: hub
+  servicePort: 80
+  methods:
+    - GET
+    - POST
+  paths:
+    - /
+    - /registration
+    - /verification
+    - /login
+    - /recovery
+    - /holaplex.svg
+    - /_next/static/*
+    - /__nextjs_original-stack-frame
+    - /api/.ory/*
 
+- name: ui-private
+  subdomain: hub
+  serviceName: hub
+  servicePort: 80
+  require_auth: true
+  methods:
+    - GET
+  paths:
+    - /organizations


### PR DESCRIPTION
updated values.gateway.yaml

Using value `hubNamespace` on the values file to allow us to deploy to 2 namespaces from the same helm chart