### PR TITLE
Set External URL on Collections

### DIFF
--- a/src/app/(drops)/projects/[project]/drops/new/details/page.tsx
+++ b/src/app/(drops)/projects/[project]/drops/new/details/page.tsx
@@ -143,6 +143,13 @@ export default function NewDropDetailsPage() {
             />
             <Form.Error message="" />
           </Form.Label>
+          <Form.Label name="External URL" className="text-xs mt-5">
+            <Form.Input
+              {...register('externalUrl')}
+              placeholder="(Optional) Set an external url on the drop."
+            />
+            <Form.Error message="" />
+          </Form.Label>
           <Form.Label name="Attribute" className="text-xs mt-5">
             {fields.map((field, index) => (
               <div className="flex gap-4" key={field.id}>

--- a/src/app/(drops)/projects/[project]/drops/new/preview/page.tsx
+++ b/src/app/(drops)/projects/[project]/drops/new/preview/page.tsx
@@ -82,6 +82,7 @@ export default function NewDropPreviewPage() {
             description: stepOne.description,
             image,
             attributes: stepOne.attributes,
+            externalUrl: stepOne.externalUrl,
           },
           creators: stepTwo.creators,
           supply: parseInt(stepTwo.supply),

--- a/src/hooks/useCreateDropStore.ts
+++ b/src/hooks/useCreateDropStore.ts
@@ -13,6 +13,7 @@ export type StepOneData = {
   description: string;
   image: File;
   attributes: Attribute[];
+  externalUrl: string;
 };
 
 export type StepTwoData = {


### PR DESCRIPTION
## Goal
Allow users to set the external url when creating a drop.

https://explorer.solana.com/address/GD9yNwPSp5ySP4LtQeXPgdcKx7CaJTEJ2vMT5BtQZYJv/metadata