### PR TITLE
Use Turbopack for the dev server

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,10 +2,13 @@
 const withGraphql = require('next-plugin-graphql');
 
 const nextConfig = {
-  output: 'standalone',
   experimental: {
+    turbo: {
+      loaders: {
+        '.graphql': ['graphql-tag/loader']
+      }
+    },
     appDir: true,
-    enableUndici: true,
     swcFileReading: false,
   },
   reactStrictMode: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint": "8.31.0",
         "formidable": "^3.2.5",
         "graphql": "^16.6.0",
+        "graphql-tag": "^2.12.6",
         "next": "^13.3.1",
         "next-plugin-graphql": "^0.0.2",
         "nft.storage": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -22,6 +22,7 @@
     "eslint": "8.31.0",
     "formidable": "^3.2.5",
     "graphql": "^16.6.0",
+    "graphql-tag": "^2.12.6",
     "next": "^13.3.1",
     "next-plugin-graphql": "^0.0.2",
     "nft.storage": "^7.0.0",


### PR DESCRIPTION
### Changes
- Switch to using turbopack for running dev server. Still build production with webhpack.