### PR TITLE
Fix: Timezone bugs - costetic ui update

### DIFF
--- a/src/app/(drops)/projects/[project]/drops/new/preview/page.tsx
+++ b/src/app/(drops)/projects/[project]/drops/new/preview/page.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../../../../../../graphql.types';
 import { StoreApi, useStore } from 'zustand';
 import { ApolloError, useMutation } from '@apollo/client';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { CreateDrop } from './../../../../../../../mutations/drop.graphql';
 import { combineDateTime, maybeToUtc, DateFormat } from '../../../../../../../modules/time';
 import { useProject } from '../../../../../../../hooks/useProject';
@@ -119,7 +119,7 @@ export default function NewDropPreviewPage() {
   if (timing.selectStartDate === 'specifyStartDate' && timing.startTime && timing.startDate) {
     const [startTimeHrs, startTimeMins] = timing.startTime.split(':');
     startDateTime = combineDateTime(
-      new Date(timing.startDate),
+      parseISO(timing.startDate),
       parseInt(startTimeHrs),
       parseInt(startTimeMins)
     );
@@ -129,7 +129,7 @@ export default function NewDropPreviewPage() {
   if (timing.selectEndDate === 'specifyEndDate' && timing.endTime && timing.endDate) {
     const [endTimeHrs, endTimeMins] = timing.endTime.split(':');
     endDateTime = combineDateTime(
-      new Date(timing.endDate),
+      parseISO(timing.endDate),
       parseInt(endTimeHrs),
       parseInt(endTimeMins)
     );

--- a/src/app/(project)/projects/[project]/drops/[drop]/Drop.tsx
+++ b/src/app/(project)/projects/[project]/drops/[drop]/Drop.tsx
@@ -6,7 +6,8 @@ import Tabs from './../../../../../../layouts/Tabs';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { GetDrop } from './../../../../../../queries/drop.graphql';
-import { DateFormat, daysUntil, inTheFuture } from './../../../../../../modules/time';
+import { format } from 'date-fns';
+import { DateFormat, daysUntil, inTheFuture, convertLocalTime } from './../../../../../../modules/time';
 import { useQuery } from '@apollo/client';
 import {
   AssetType,
@@ -21,7 +22,6 @@ import clsx from 'clsx';
 import { cloneElement } from 'react';
 import Typography, { Size } from '../../../../../../components/Typography';
 import { shorten } from '../../../../../../modules/wallet';
-import { format } from 'util';
 import { useRouter } from 'next/navigation';
 
 type Drop = {
@@ -152,7 +152,6 @@ export default function Drop({ children, project, drop }: DropProps): JSX.Elemen
                 disabled={dropQuery?.data?.project?.drop?.status !== DropStatus.Minting}
                 onClick={() => {
                   if (dropQuery?.data?.project?.drop?.status !== DropStatus.Minting) return
-                  
                   router.push(`/projects/${project}/drops/${drop}/mint`)
                 }}
                 >Mint edition</Button>
@@ -311,23 +310,17 @@ export default function Drop({ children, project, drop }: DropProps): JSX.Elemen
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-gray-400">Starts</span>
                     <span>
-                      {dropData?.startTime
-                        ? `${format(dropData?.startTime, DateFormat.DATE_1)}, ${format(
-                            dropData?.startTime,
-                            DateFormat.TIME_1
-                          )}`
-                        : 'Immediately'}
+                    {dropData?.startTime
+                      ? `${format(convertLocalTime(dropData?.startTime), DateFormat.DATE_2)}`
+                      : 'Immediately'}
                     </span>
                   </div>
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-gray-400">Ends</span>
                     <span>
                       {dropData?.endTime
-                        ? `${format(dropData?.endTime, DateFormat.DATE_1)}, ${format(
-                            dropData?.endTime,
-                            DateFormat.TIME_1
-                          )}`
-                        : 'Never'}
+                      ? `${format(convertLocalTime(dropData?.endTime), DateFormat.DATE_2)}`
+                      : 'Never'}
                     </span>
                   </div>
                   {dropData?.collection.metadataJson?.externalUrl && (


### PR DESCRIPTION
fixes:
-  startDate day drifting by one when creating drops
- drops displaying wrong value for start+end dates in the drop details page

![image](https://github.com/holaplex/hub/assets/13471075/1ea1dd53-918e-4d4e-a9f6-6256c8a7feec)


---
![image](https://github.com/holaplex/hub/assets/13471075/485b0729-247c-474d-8718-75ba5e1f1533)
