### PR TITLE
add cert-manager to skaffold.yaml, update hub-gateway values 

### DIFF
--- a/.helm/values.gateway.yaml
+++ b/.helm/values.gateway.yaml
@@ -4,9 +4,23 @@ port: 9080
 sessionCookieName: 'hub_session'
 forceVerification: false
 verificationUri: 'http://hub.127.0.0.1.nip.io:9080/verification'
+
+certificates:
+  deploy: true
+  devMode: true
+  email: "engineering@holaplex.com"
+
 apisix:
   configurationSnippet:
     httpStart: |
       proxy_read_timeout 300;
       proxy_connect_timeout 300;
       proxy_send_timeout 300;
+
+  gateway:
+      type: NodePort
+      externalTrafficPolicy: Cluster
+      tls:
+        enabled: true
+        servicePort: 443
+        containerPort: 9443

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -9,7 +9,7 @@ build:
         target: development
         dockerfile: Dockerfile
         buildArgs:
-          APP_FQDN: http://hub.127.0.0.1.nip.io:9443
+          APP_FQDN: https://hub.127.0.0.1.nip.io:9443
       sync:
         manual:
           - src: 'src/**/*.tsx'

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -9,7 +9,7 @@ build:
         target: development
         dockerfile: Dockerfile
         buildArgs:
-          APP_FQDN: http://hub.127.0.0.1.nip.io:9080
+          APP_FQDN: http://hub.127.0.0.1.nip.io:9443
       sync:
         manual:
           - src: 'src/**/*.tsx'
@@ -27,6 +27,11 @@ portForward:
   - resourceType: service
     resourceName: apisix-gateway
     namespace: ingress-apisix
+    port: 443
+    localPort: 9443
+  - resourceType: service
+    resourceName: apisix-gateway
+    namespace: ingress-apisix
     port: 80
     localPort: 9080
   - resourceType: service
@@ -37,6 +42,13 @@ portForward:
 deploy:
   helm:
     releases:
+      - name: cert-manager
+        createNamespace: true
+        remoteChart: cert-manager
+        namespace: cert-manager
+        repo: https://charts.jetstack.io
+        setValueTemplates:
+          installCRDs: true
       - name: hub-gateway
         createNamespace: true
         namespace: ingress-apisix
@@ -196,7 +208,7 @@ deploy:
           - .helm/secrets.credentials.yaml
       - name: federated-router
         remoteChart: oci://ghcr.io/apollographql/helm-charts/router
-        version: 1.19.0
+        version: 1.30.0
         valuesFiles:
           - .helm/values.router.yaml
           - .helm/secrets.router.yaml


### PR DESCRIPTION
this PR deploys self-signed certs when in devMode.
an exception needs to be accepted because its selfSigned certificates.

https endpoint has been enabled in  port `9443`

```
curl --insecure -vvI https://hub.127.0.0.1.nip.io:9443
*   Trying 127.0.0.1:9443...
* Connected to hub.127.0.0.1.nip.io (127.0.0.1) port 9443 (#0)
* ALPN: offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=selfsigned-ca
*  start date: Oct  3 06:31:50 2023 GMT
*  expire date: Jan  1 06:31:50 2024 GMT
*  issuer: CN=selfsigned-ca
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/2
* h2 [:method: HEAD]
* h2 [:scheme: https]
* h2 [:authority: hub.127.0.0.1.nip.io:9443]
* h2 [:path: /]
* h2 [user-agent: curl/8.1.2]
* h2 [accept: */*]
* Using Stream ID: 1 (easy handle 0x150814800)
> HEAD / HTTP/2
> Host: hub.127.0.0.1.nip.io:9443
> User-Agent: curl/8.1.2
> Accept: */*
>
```
